### PR TITLE
fix: news astro:before-swap handler read wrong event shape

### DIFF
--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -343,6 +343,8 @@ const nonce = Astro.locals.nonce;
 </Layout>
 
 <script>
+  import type { TransitionBeforeSwapEvent } from "astro:transitions/client";
+
   document.addEventListener("astro:page-load", () => {
     // CRITICAL: Only run on the news index page, not article or tag pages
     if (window.location.pathname !== '/news') {
@@ -417,9 +419,9 @@ const nonce = Astro.locals.nonce;
   });
 
   // CRITICAL: Clean URL parameters when leaving news section
-  document.addEventListener("astro:before-swap", (e: any) => {
-    const newUrl = e.detail?.to?.pathname || '';
-    
+  document.addEventListener("astro:before-swap", (e: TransitionBeforeSwapEvent) => {
+    const newUrl = e.to.pathname;
+
     // If we're leaving news section, clean up view parameters from forms
     if (window.location.pathname.startsWith('/news') && !newUrl.startsWith('/news')) {
       const forms = document.querySelectorAll('form');


### PR DESCRIPTION
## Summary
- `astro:before-swap` handler in `src/pages/news/index.astro` read `e.detail?.to?.pathname`, which is always undefined on Astro 7's `TransitionBeforeSwapEvent` — the target URL is exposed as `e.to` directly, not nested under `.detail`.
- The leaving-news-section check always evaluated true as a result, so view-param form cleanup ran unconditionally instead of only when navigating out of `/news`.
- Fixed to read `e.to.pathname` with proper `TransitionBeforeSwapEvent` typing, matching the correct pattern already used in `src/layouts/Layout.astro`.

## Test plan
- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm test:run` — 851/851 passing
- [ ] Manual verification in browser (blocked locally by another running Astro dev server holding the default ports — logic traced against the working `Layout.astro` reference pattern instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)